### PR TITLE
fix: enforce a static build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Build
         run: |
-          GOOS=linux GOARCH=amd64 go build -o bin/tc-redirect-tap-amd64 ./cmd/tc-redirect-tap
-          GOOS=linux GOARCH=arm64 go build -o bin/tc-redirect-tap-arm64 ./cmd/tc-redirect-tap
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/tc-redirect-tap-amd64 ./cmd/tc-redirect-tap
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/tc-redirect-tap-arm64 ./cmd/tc-redirect-tap
 
       - name: Sign
         run: |

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ CNI_BIN_ROOT?=/opt/cni/bin
 all: tc-redirect-tap
 
 tc-redirect-tap: $(SOURCES) $(GOMOD) $(GOSUM)
-	go build -o tc-redirect-tap $(CURDIR)/cmd/tc-redirect-tap
+	CGO_ENABLED=0 go build -o tc-redirect-tap $(CURDIR)/cmd/tc-redirect-tap
 
 .PHONY: install
 install: tc-redirect-tap


### PR DESCRIPTION
Looking at the other cni plugins being used in [Nex](https://github.com/synadia-io/nex), they all appear to be static binaries:

```terminal
❯ ldd /opt/cni/bin/host-local
        not a dynamic executable

❯ ldd /opt/cni/bin/ptp
        not a dynamic executable
```

Whereas the `tc-redirect-tap` release is dynamic:

```terminal
❯ wget https://github.com/jordan-rash/tc-redirect-tap/releases/download/v0.0.1/tc-redirect-tap-amd64
...

tc-redirect-tap-amd64                                         100%[=================================================================================================================================================>]   3.68M  --.-KB/s    in 0.07s   

2024-02-07 11:55:05 (50.0 MB/s) - ‘tc-redirect-tap-amd64’ saved [3858998/3858998]

❯ ldd tc-redirect-tap-amd64 
ldd: warning: you do not have execution permission for `./tc-redirect-tap-amd64'
        linux-vdso.so.1 (0x00007ffcff70a000)
        libpthread.so.0 => /nix/store/qn3ggz5sf3hkjs2c797xf7nan3amdxmp-glibc-2.38-27/lib/libpthread.so.0 (0x00007f2c71db5000)
        libc.so.6 => /nix/store/qn3ggz5sf3hkjs2c797xf7nan3amdxmp-glibc-2.38-27/lib/libc.so.6 (0x00007f2c71bcd000)
        /lib64/ld-linux-x86-64.so.2 => /nix/store/qn3ggz5sf3hkjs2c797xf7nan3amdxmp-glibc-2.38-27/lib64/ld-linux-x86-64.so.2 (0x00007f2c71dbc000)
```

This fix ensures a static build, as can be seen with [this release](https://github.com/brianmcgee/tc-redirect-tap/releases/download/v0.0.2/tc-redirect-tap-amd64):

```terminal
❯ wget https://github.com/brianmcgee/tc-redirect-tap/releases/download/v0.0.2/tc-redirect-tap-amd64
...

tc-redirect-tap-amd64                                         100%[=================================================================================================================================================>]   3.66M  --.-KB/s    in 0.07s   

2024-02-07 11:59:19 (50.6 MB/s) - ‘tc-redirect-tap-amd64’ saved [3833051/3833051]

❯ ldd tc-redirect-tap-amd64 
ldd: warning: you do not have execution permission for `./tc-redirect-tap-amd64'
        not a dynamic executable
```